### PR TITLE
[0.13] release-notes: Do not encourage changing blockmaxsize to blockmaxweight

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -192,21 +192,6 @@ is unaffected by this distinction (as BIP 141 activation is not supported on
 mainnet in this release, see above), but in future releases and after BIP 141
 activation, these calculations would be expected to differ.
 
-For optimal runtime performance, miners using this release should specify
-`-blockmaxweight` on the command line, and not specify `-blockmaxsize`.
-Additionally (or only) specifying `-blockmaxsize`, or relying on default
-settings for both, may result in performance degradation, as the logic to
-support `-blockmaxsize` performs additional computation to ensure that
-constraint is met.  (Note that for mainnet, in this release, the equivalent
-parameter for `-blockmaxweight` would be four times the desired
-`-blockmaxsize`.  See [BIP 141]
-(https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki) for additional
-details.)
-
-In the future, the `-blockmaxsize` option may be removed, as block creation is
-no longer optimized for this metric.  Feedback is requested on whether to
-deprecate or keep this command line option in future releases.
-
 
 Removal of internal miner
 --------------------------

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -186,11 +186,11 @@ maximum "block weight" of a generated block, as defined by [BIP 141 (Segregated
 Witness)] (https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki).
 
 In preparation for Segregated Witness, the mining algorithm has been modified
-to optimize transaction selection for a given block weight, rather than a given
-number of serialized bytes in a block.  In this release, transaction selection
-is unaffected by this distinction (as BIP 141 activation is not supported on
-mainnet in this release, see above), but in future releases and after BIP 141
-activation, these calculations would be expected to differ.
+to choose transactions to mine based on their block weight, rather than number
+of serialized bytes.  In this release, transaction selection is unaffected by
+this distinction (as BIP 141 activation is not supported on mainnet in this
+release, see above), but in future releases and after BIP 141 activation,
+these calculations would be expected to differ.
 
 
 Removal of internal miner


### PR DESCRIPTION
Alternative to #8388 without the code changes. Since the only difference is adding numbers, there shouldn't be any noticable performance hit with blockmaxsize anyway.

(If we want to eliminate any difference just in case, another code change possibility would be to simply translate blockmaxsize to blockmaxweight when segwit is not enabled (ie, mainnet): 29000050e575a26b7f7c853cbccdb6bc60ddfdd9.)
