### PR TITLE
Add maximal amount-of-transactions limit to checkblock/CVerifyDB

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -310,6 +310,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-blocksonly", strprintf(_("Whether to operate in a blocks only mode (default: %u)"), DEFAULT_BLOCKSONLY));
     strUsage += HelpMessageOpt("-checkblocks=<n>", strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), DEFAULT_CHECKBLOCKS));
     strUsage += HelpMessageOpt("-checklevel=<n>", strprintf(_("How thorough the block verification of -checkblocks is (0-4, default: %u)"), DEFAULT_CHECKLEVEL));
+    strUsage += HelpMessageOpt("-checkmaxtx=<n>", strprintf(_("Maximal amount of transactions to check during the verification of -checkblocks (default: %u, 0 = unlimited)"), DEFAULT_CHECKMAXTX));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), BITCOIN_CONF_FILENAME));
     if (mode == HMM_BITCOIND)
     {
@@ -1291,7 +1292,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                 }
 
                 if (!CVerifyDB().VerifyDB(chainparams, pcoinsdbview, GetArg("-checklevel", DEFAULT_CHECKLEVEL),
-                              GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
+                              GetArg("-checkblocks", DEFAULT_CHECKBLOCKS), GetArg("-checkmaxtx", DEFAULT_CHECKMAXTX))) {
                     strLoadError = _("Corrupted block database detected");
                     break;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3855,7 +3855,7 @@ CVerifyDB::~CVerifyDB()
     uiInterface.ShowProgress("", 100);
 }
 
-bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview, int nCheckLevel, int nCheckDepth)
+bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview, int nCheckLevel, int nCheckDepth, int nTxCheckLimit)
 {
     LOCK(cs_main);
     if (chainActive.Tip() == NULL || chainActive.Tip()->pprev == NULL)
@@ -3872,6 +3872,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     CBlockIndex* pindexState = chainActive.Tip();
     CBlockIndex* pindexFailure = NULL;
     int nGoodTransactions = 0;
+    int nTxCheckLimitCurrent = 0;
     CValidationState state;
     for (CBlockIndex* pindex = chainActive.Tip(); pindex && pindex->pprev; pindex = pindex->pprev)
     {
@@ -3915,6 +3916,11 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         }
         if (ShutdownRequested())
             return true;
+        nTxCheckLimitCurrent+=block.vtx.size();
+        if (nTxCheckLimit > 0 && nTxCheckLimitCurrent >= nTxCheckLimit && chainActive.Height() - pindex->nHeight >= std::min(nCheckDepth, MIN_BLOCK_TO_RESPECT_WITH_MAX_TX_CHECK)) {
+            LogPrintf("VerifyDB(): reached max transaction limit (%d)\n", nTxCheckLimit);
+            break;
+        }
     }
     if (pindexFailure)
         return error("VerifyDB(): *** coin database inconsistencies found (last %i blocks, %i good transactions before that)\n", chainActive.Height() - pindexFailure->nHeight + 1, nGoodTransactions);

--- a/src/main.h
+++ b/src/main.h
@@ -185,8 +185,11 @@ extern uint64_t nPruneTarget;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
 static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
 
-static const signed int DEFAULT_CHECKBLOCKS = MIN_BLOCKS_TO_KEEP;
+static const signed int DEFAULT_CHECKBLOCKS = MIN_BLOCKS_TO_KEEP / 2;
 static const unsigned int DEFAULT_CHECKLEVEL = 3;
+
+static const signed int MIN_BLOCK_TO_RESPECT_WITH_MAX_TX_CHECK = 6;
+static const unsigned int DEFAULT_CHECKMAXTX = 100000;
 
 // Require that user allocate at least 550MB for block & undo files (blk???.dat and rev???.dat)
 // At 1MB per block, 288 blocks = 288MB.
@@ -454,7 +457,7 @@ class CVerifyDB {
 public:
     CVerifyDB();
     ~CVerifyDB();
-    bool VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview, int nCheckLevel, int nCheckDepth);
+    bool VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview, int nCheckLevel, int nCheckDepth, int nTxCheckLimit);
 };
 
 /** Find the last common block between the parameter chain and a locator. */

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -611,13 +611,15 @@ UniValue verifychain(const UniValue& params, bool fHelp)
 {
     int nCheckLevel = GetArg("-checklevel", DEFAULT_CHECKLEVEL);
     int nCheckDepth = GetArg("-checkblocks", DEFAULT_CHECKBLOCKS);
-    if (fHelp || params.size() > 2)
+    int nCheckMaxTx = GetArg("-checkmaxtx", DEFAULT_CHECKMAXTX);
+    if (fHelp || params.size() > 3)
         throw runtime_error(
-            "verifychain ( checklevel numblocks )\n"
+            "verifychain ( checklevel numblocks maxnumtxs )\n"
             "\nVerifies blockchain database.\n"
             "\nArguments:\n"
             "1. checklevel   (numeric, optional, 0-4, default=" + strprintf("%d", nCheckLevel) + ") How thorough the block verification is.\n"
             "2. numblocks    (numeric, optional, default=" + strprintf("%d", nCheckDepth) + ", 0=all) The number of blocks to check.\n"
+            "3. maxnumtxs    (numeric, optional, default=" + strprintf("%d", nCheckMaxTx) + ", 0=unlimited) The maximal number of transactions to check.\n"
             "\nResult:\n"
             "true|false       (boolean) Verified or not\n"
             "\nExamples:\n"
@@ -631,8 +633,9 @@ UniValue verifychain(const UniValue& params, bool fHelp)
         nCheckLevel = params[0].get_int();
     if (params.size() > 1)
         nCheckDepth = params[1].get_int();
-
-    return CVerifyDB().VerifyDB(Params(), pcoinsTip, nCheckLevel, nCheckDepth);
+    if (params.size() > 2)
+        nCheckMaxTx = params[2].get_int();
+    return CVerifyDB().VerifyDB(Params(), pcoinsTip, nCheckLevel, nCheckDepth, nCheckMaxTx);
 }
 
 /** Implementation of IsSuperMajority with better feedback */


### PR DESCRIPTION
**Reduces checkblocks default to 144 blocks (`MIN_BLOCKS_TO_KEEP / 2`).**

Introduce `-checkmaxtx` with a default of `100'000` transaction to set a upper bound of amount of transaction to check during the CVerifyDB process.

There is also a new constant `MIN_BLOCK_TO_RESPECT_WITH_MAX_TX_CHECK` which defines the minimum amount of blocks to check even if the `-checkmaxtx` check has been fulfilled.
