### PR TITLE
[qa] Fix race condition in p2p-compactblocks test

### DIFF
--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -237,6 +237,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         for i in range(num_transactions):
             self.nodes[0].sendtoaddress(address, 0.1)
 
+        self.test_node.sync_with_ping()
+
         # Now mine a block, and look at the resulting compact block.
         self.test_node.clear_block_announcement()
         block_hash = int(self.nodes[0].generate(1)[0], 16)

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1536,7 +1536,7 @@ class SingleNodeConnCB(NodeConnCB):
         def received_pong():
             return (self.last_pong.nonce == self.ping_counter)
         self.send_message(msg_ping(nonce=self.ping_counter))
-        success = wait_until(received_pong, timeout)
+        success = wait_until(received_pong, timeout=timeout)
         self.ping_counter += 1
         return success
 


### PR DESCRIPTION
Also fix a bug in the sync_with_ping() helper function.

I believe this fixes #8842.  For others trying to debug -- I was able to reproduce the issue by setting the deliver_sleep_time in NodeConnCB to 0.5 seconds, and then confirm that this patch fixes it.

I think there are likely other places in the tests where wait_until() may be used with incorrect arguments, just like the bug fix to sync_with_ping().  I'll try to clean those up in another PR.
