### PR TITLE
signal handling: fReopenDebugLog and fRequestShutdown should be type sig_atomic_t

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -125,7 +125,7 @@ static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 // shutdown thing.
 //
 
-volatile bool fRequestShutdown = false;
+volatile sig_atomic_t fRequestShutdown = false;
 
 void StartShutdown()
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -113,7 +113,7 @@ string strMiscWarning;
 bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
 bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
 bool fLogIPs = DEFAULT_LOGIPS;
-volatile bool fReopenDebugLog = false;
+volatile sig_atomic_t fReopenDebugLog = false;
 CTranslationInterface translationInterface;
 
 /** Init OpenSSL library multithreading support */

--- a/src/util.h
+++ b/src/util.h
@@ -28,6 +28,10 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/exceptions.hpp>
 
+#ifndef WIN32
+#include <signal.h>
+#endif
+
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
@@ -50,7 +54,7 @@ extern std::string strMiscWarning;
 extern bool fLogTimestamps;
 extern bool fLogTimeMicros;
 extern bool fLogIPs;
-extern volatile bool fReopenDebugLog;
+extern volatile sig_atomic_t fReopenDebugLog;
 extern CTranslationInterface translationInterface;
 
 extern const char * const BITCOIN_CONF_FILENAME;


### PR DESCRIPTION
This allows access as an atomic variable in the presence of async interrupts.

See issue #7433 for more details
fixes: #7433
