### PR TITLE
Docs: Fixed invalid example paths in gitian-building.md

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -443,8 +443,8 @@ Then when building, override the remote URLs that gbuild would otherwise pull fr
 cd /some/root/path/
 git clone https://github.com/bitcoin-core/bitcoin-detached-sigs.git
 
-BTCPATH=/some/root/path/bitcoin.git
-SIGPATH=/some/root/path/bitcoin-detached-sigs.git
+BTCPATH=/some/root/path/bitcoin
+SIGPATH=/some/root/path/bitcoin-detached-sigs
 
 ./bin/gbuild --url bitcoin=${BTCPATH},signature=${SIGPATH} ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
 ```


### PR DESCRIPTION
The example local paths for "Building fully offline" were missing a forward slash prior to the ".git".  This caused an error when trying to run gbuild, like this:

```
fatal: '/home/user/bitcoin.git' does not appear to be a git repository
fatal: Could not read from remote repository.
```

This PR fixes that.
