### PR TITLE
wallet: Automatically repair corrupted metadata with doubled derivation path

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -523,7 +523,7 @@ static LoadResult LoadRecords(CWallet* pwallet, DatabaseBatch& batch, const std:
     return LoadRecords(pwallet, batch, key, prefix, load_func);
 }
 
-static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, int last_client) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, WalletBatch& w_batch, int last_client) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     AssertLockHeld(pwallet->cs_wallet);
     DBErrors result = DBErrors::LOAD_OK;
@@ -598,13 +598,13 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
 
     // Load keymeta
     std::map<uint160, CHDChain> hd_chains;
+    std::vector<CPubKey> updated_metas;
     LoadResult keymeta_res = LoadRecords(pwallet, batch, DBKeys::KEYMETA,
-        [&hd_chains] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& strErr) {
+        [&hd_chains, &updated_metas] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& strErr) {
         CPubKey vchPubKey;
         key >> vchPubKey;
         CKeyMetadata keyMeta;
         value >> keyMeta;
-        pwallet->GetOrCreateLegacyScriptPubKeyMan()->LoadKeyMetadata(vchPubKey.GetID(), keyMeta);
 
         // Extract some CHDChain info from this metadata if it has any
         if (keyMeta.nVersion >= CKeyMetadata::VERSION_WITH_HDDATA && !keyMeta.hd_seed_id.IsNull() && keyMeta.hdKeypath.size() > 0) {
@@ -615,13 +615,32 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
             uint32_t index = 0;
             if (keyMeta.hdKeypath != "s" && keyMeta.hdKeypath != "m") {
                 std::vector<uint32_t> path;
-                if (keyMeta.has_key_origin) {
-                    // We have a key origin, so pull it from its path vector
-                    path = keyMeta.key_origin.path;
-                } else {
-                    // No key origin, have to parse the string
-                    if (!ParseHDKeypath(keyMeta.hdKeypath, path)) {
-                        strErr = "Error reading wallet database: keymeta with invalid HD keypath";
+                // Always parse the path string
+                if (!ParseHDKeypath(keyMeta.hdKeypath, path)) {
+                    strErr = "Error reading wallet database: keymeta with invalid HD keypath";
+                    return DBErrors::NONCRITICAL_ERROR;
+                }
+                // If there is a key origin, make sure that path matches
+                if (keyMeta.has_key_origin && path != keyMeta.key_origin.path) {
+                    // Detect if this metadata has a bad derivation path from a bug in inactive hd key derivation that was present in 0.21 and 22.x
+                    // See https://github.com/bitcoin/bitcoin/issues/29109
+                    // Markers for bad derivation:
+                    // - 6 indexes
+                    // - path[5] == path[2] + 1
+                    // - path[0:2] == path[3:5]
+                    // - path[3:6] matches hdKeypath
+                    if (keyMeta.key_origin.path.size() == 6
+                        && keyMeta.key_origin.path[5] == keyMeta.key_origin.path[2] + 1
+                        && keyMeta.key_origin.path[0] == keyMeta.key_origin.path[3]
+                        && keyMeta.key_origin.path[1] == keyMeta.key_origin.path[4]
+                        && std::equal(keyMeta.key_origin.path.begin() + 3, keyMeta.key_origin.path.end(), path.begin(), path.end())
+                    ) {
+                        // Matches the pattern, just reset it to the parsed path
+                        pwallet->WalletLogPrintf("Repairing derivation path for %s\n", HexStr(vchPubKey));
+                        keyMeta.key_origin.path = path;
+                        updated_metas.push_back(vchPubKey);
+                    } else {
+                        strErr = "keymeta with mismatched hdkeypath string and key origin derivation path";
                         return DBErrors::NONCRITICAL_ERROR;
                     }
                 }
@@ -665,9 +684,22 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
                 chain.nExternalChainCounter = std::max(chain.nExternalChainCounter, index + 1);
             }
         }
+
+        pwallet->GetOrCreateLegacyScriptPubKeyMan()->LoadKeyMetadata(vchPubKey.GetID(), keyMeta);
+
         return DBErrors::LOAD_OK;
     });
     result = std::max(result, keymeta_res.m_result);
+
+    // Update any changed metadata
+    if (updated_metas.size()) {
+        LegacyScriptPubKeyMan* spkm = pwallet->GetLegacyScriptPubKeyMan();
+        Assert(spkm);
+        LOCK(spkm->cs_KeyStore);
+        for (const auto& pubkey : updated_metas) {
+            w_batch.WriteKeyMetadata(spkm->mapKeyMetadata.at(pubkey.GetID()), pubkey, true);
+        }
+    }
 
     // Set inactive chains
     if (!hd_chains.empty()) {
@@ -1171,7 +1203,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 #endif
 
         // Load legacy wallet keys
-        result = std::max(LoadLegacyWalletRecords(pwallet, *m_batch, last_client), result);
+        result = std::max(LoadLegacyWalletRecords(pwallet, *m_batch, *this, last_client), result);
 
         // Load descriptors
         result = std::max(LoadDescriptorWalletRecords(pwallet, *m_batch, last_client), result);

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -41,7 +41,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v25.0
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v24.0.1
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v23.0
-            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v22.0
+            ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1", "-keypool=10"], # v22.0
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v0.21.0
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v0.20.1
             ["-nowallet", "-walletrbf=1", "-addresstype=bech32", "-whitelist=noban@127.0.0.1"], # v0.19.1
@@ -129,6 +129,77 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         node_v19.loadwallet("w1_v19")
         wallet = node_v19.get_wallet_rpc("w1_v19")
         assert wallet.getaddressinfo(address_18075)["solvable"]
+
+
+    def test_v22_inactivehdchain_path(self):
+        if self.options.descriptors:
+            return
+
+        self.log.info("Testing inactive hd chain bad derivation path cleanup")
+        # 0.21.x and 22.x would both produce bad derivation paths when topping up an inactive hd chain
+        # Make sure that this is being detected and automatically cleaned up
+        node_master = self.nodes[1]
+        node_v22 = self.nodes[self.num_nodes - 7]
+        wallet_name = "bad_deriv_path"
+        node_v22.createwallet(wallet_name=wallet_name, descriptors=False)
+        wallet = node_v22.get_wallet_rpc(wallet_name)
+
+        # Make a dump of the wallet to get an unused address
+        dump_path = node_v22.wallets_path / f"{wallet_name}.dump"
+        wallet.dumpwallet(dump_path)
+        addr = None
+        seed = None
+        with open(dump_path, encoding="utf8") as f:
+            for line in f:
+                if "hdkeypath=m/0'/0'/9'" in line:
+                    addr = line.split(" ")[4].split("=")[1]
+                elif " hdseed=1 " in line:
+                    seed = line.split(" ")[0]
+        assert addr is not None
+        assert seed is not None
+        # Rotate seed and unload
+        wallet.sethdseed()
+        wallet.unloadwallet()
+        # Receive at addr to trigger inactive chain topup on next load
+        self.nodes[0].sendtoaddress(addr, 1)
+        self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+        self.sync_all(nodes=[self.nodes[0], node_master, node_v22])
+        node_v22.loadwallet(wallet_name)
+
+        # Dump again to find bad hd keypath
+        bad_deriv_path = "m/0'/0'/9'/0'/0'/10'"
+        good_deriv_path = "m/0'/0'/10'"
+        os.unlink(dump_path)
+        wallet.dumpwallet(dump_path)
+        bad_path_addr = None
+        with open(dump_path, encoding="utf8") as f:
+            for line in f:
+                if f"hdkeypath={bad_deriv_path}" in line:
+                    bad_path_addr = line.split(" ")[4].split("=")[1]
+        assert bad_path_addr is not None
+        assert_equal(wallet.getaddressinfo(bad_path_addr)["hdkeypath"], bad_deriv_path)
+
+        # Verify that this addr is actually at m/0'/0'/10' by making a new wallet with the same seed
+        node_v22.createwallet(wallet_name="path_verify", descriptors=False, blank=True)
+        verify_wallet = node_v22.get_wallet_rpc("path_verify")
+        verify_wallet.sethdseed(True, seed)
+        # Bad addr is after keypool, so need to generate it by refilling
+        verify_wallet.keypoolrefill(12)
+        assert_equal(verify_wallet.getaddressinfo(bad_path_addr)["hdkeypath"], good_deriv_path)
+
+        # Load into master, the path should now be fixed
+        backup_path = node_v22.wallets_path / f"{wallet_name}.bak"
+        wallet.backupwallet(backup_path)
+        with node_master.assert_debug_log(expected_msgs=["Repairing derivation path for"]):
+            node_master.restorewallet(wallet_name, backup_path)
+        wallet_master = node_master.get_wallet_rpc(wallet_name)
+        assert_equal(wallet_master.getaddressinfo(bad_path_addr)["hdkeypath"], good_deriv_path)
+
+        # Check persistence
+        wallet_master.unloadwallet()
+        with node_master.assert_debug_log(expected_msgs=[], unexpected_msgs=["Repairing derivation path for"]):
+            node_master.loadwallet(wallet_name)
+        assert_equal(wallet_master.getaddressinfo(bad_path_addr)["hdkeypath"], good_deriv_path)
 
     def run_test(self):
         node_miner = self.nodes[0]
@@ -379,6 +450,8 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
                 wallet_res = node.get_wallet_rpc(down_wallet_name)
                 info = wallet_res.getaddressinfo(address)
                 assert_equal(info, addr_info)
+
+        self.test_v22_inactivehdchain_path()
 
 if __name__ == '__main__':
     BackwardsCompatibilityTest().main()


### PR DESCRIPTION
A bug in 0.21.x and 22.x resulted in some wallets storing invalid derivation paths that are the concatenation of two derivation paths. This corruption follows a rigid pattern and can be easily detected and repaired.

The bug that resulted in such wallets was fixed in #23304 but wallets that already ran into it would still have bad data stored. This PR should fix such wallets.

Fixes #29109