### PR TITLE
fuzz: Avoid timeout in EncodeBase58

### DIFF
--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -168,6 +168,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
 std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider)
 {
     const size_t max_string_length = 4096;
+    const size_t max_base58_bytes_length{64};
     std::string r;
     CallOneOf(
         fuzzed_data_provider,
@@ -221,11 +222,11 @@ std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider)
         },
         [&] {
             // base58 argument
-            r = EncodeBase58(MakeUCharSpan(fuzzed_data_provider.ConsumeRandomLengthString(max_string_length)));
+            r = EncodeBase58(MakeUCharSpan(fuzzed_data_provider.ConsumeRandomLengthString(max_base58_bytes_length)));
         },
         [&] {
             // base58 argument with checksum
-            r = EncodeBase58Check(MakeUCharSpan(fuzzed_data_provider.ConsumeRandomLengthString(max_string_length)));
+            r = EncodeBase58Check(MakeUCharSpan(fuzzed_data_provider.ConsumeRandomLengthString(max_base58_bytes_length)));
         },
         [&] {
             // hex encoded block


### PR DESCRIPTION
The complexity is O(N^2), so limit the size.

Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34126

Oss-Fuzz testcase for `rpc` fuzzer: https://github.com/bitcoin/bitcoin/files/6461382/clusterfuzz-testcase-minimized-rpc-4831734974775296.log