### PR TITLE
test: fix creation of "std::string"s with \0s

### DIFF
--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -6,6 +6,9 @@
 #include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
+#include <string>
+
+using namespace std::literals;
 
 BOOST_FIXTURE_TEST_SUITE(base32_tests, BasicTestingSetup)
 
@@ -23,14 +26,14 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
 
     // Decoding strings with embedded NUL characters should fail
     bool failure;
-    (void)DecodeBase32(std::string("invalid", 7), &failure);
-    BOOST_CHECK_EQUAL(failure, true);
-    (void)DecodeBase32(std::string("AWSX3VPP", 8), &failure);
-    BOOST_CHECK_EQUAL(failure, false);
-    (void)DecodeBase32(std::string("AWSX3VPP\0invalid", 16), &failure);
-    BOOST_CHECK_EQUAL(failure, true);
-    (void)DecodeBase32(std::string("AWSX3VPPinvalid", 15), &failure);
-    BOOST_CHECK_EQUAL(failure, true);
+    (void)DecodeBase32("invalid\0"s, &failure); // correct size, invalid due to \0
+    BOOST_CHECK(failure);
+    (void)DecodeBase32("AWSX3VPP"s, &failure); // valid
+    BOOST_CHECK(!failure);
+    (void)DecodeBase32("AWSX3VPP\0invalid"s, &failure); // correct size, invalid due to \0
+    BOOST_CHECK(failure);
+    (void)DecodeBase32("AWSX3VPPinvalid"s, &failure); // invalid size
+    BOOST_CHECK(failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -12,7 +12,9 @@
 #include <univalue.h>
 
 #include <boost/test/unit_test.hpp>
+#include <string>
 
+using namespace std::literals;
 
 extern UniValue read_json(const std::string& jsondata);
 
@@ -58,14 +60,14 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
         BOOST_CHECK_MESSAGE(result.size() == expected.size() && std::equal(result.begin(), result.end(), expected.begin()), strTest);
     }
 
-    BOOST_CHECK(!DecodeBase58("invalid", result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("invalid"), result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("\0invalid", 8), result, 100));
+    BOOST_CHECK(!DecodeBase58("invalid"s, result, 100));
+    BOOST_CHECK(!DecodeBase58("invalid\0"s, result, 100));
+    BOOST_CHECK(!DecodeBase58("\0invalid"s, result, 100));
 
-    BOOST_CHECK(DecodeBase58(std::string("good", 4), result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("bad0IOl", 7), result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("goodbad0IOl", 11), result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("good\0bad0IOl", 12), result, 100));
+    BOOST_CHECK(DecodeBase58("good"s, result, 100));
+    BOOST_CHECK(!DecodeBase58("bad0IOl"s, result, 100));
+    BOOST_CHECK(!DecodeBase58("goodbad0IOl"s, result, 100));
+    BOOST_CHECK(!DecodeBase58("good\0bad0IOl"s, result, 100));
 
     // check that DecodeBase58 skips whitespace, but still fails with unexpected non-whitespace at the end.
     BOOST_CHECK(!DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t a", result, 3));
@@ -73,10 +75,10 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
     std::vector<unsigned char> expected = ParseHex("971a55");
     BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
 
-    BOOST_CHECK(DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oh", 21), result, 100));
-    BOOST_CHECK(!DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oi", 21), result, 100));
-    BOOST_CHECK(!DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oh0IOl", 25), result, 100));
-    BOOST_CHECK(!DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oh\00IOl", 26), result, 100));
+    BOOST_CHECK(DecodeBase58Check("3vQB7B6MrGQZaxCuFg4oh"s, result, 100));
+    BOOST_CHECK(!DecodeBase58Check("3vQB7B6MrGQZaxCuFg4oi"s, result, 100));
+    BOOST_CHECK(!DecodeBase58Check("3vQB7B6MrGQZaxCuFg4oh0IOl"s, result, 100));
+    BOOST_CHECK(!DecodeBase58Check("3vQB7B6MrGQZaxCuFg4oh\0" "0IOl"s, result, 100));
 }
 
 BOOST_AUTO_TEST_CASE(base58_random_encode_decode)

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -6,6 +6,9 @@
 #include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
+#include <string>
+
+using namespace std::literals;
 
 BOOST_FIXTURE_TEST_SUITE(base64_tests, BasicTestingSetup)
 
@@ -23,14 +26,14 @@ BOOST_AUTO_TEST_CASE(base64_testvectors)
 
     // Decoding strings with embedded NUL characters should fail
     bool failure;
-    (void)DecodeBase64(std::string("invalid", 7), &failure);
-    BOOST_CHECK_EQUAL(failure, true);
-    (void)DecodeBase64(std::string("nQB/pZw=", 8), &failure);
-    BOOST_CHECK_EQUAL(failure, false);
-    (void)DecodeBase64(std::string("nQB/pZw=\0invalid", 16), &failure);
-    BOOST_CHECK_EQUAL(failure, true);
-    (void)DecodeBase64(std::string("nQB/pZw=invalid", 15), &failure);
-    BOOST_CHECK_EQUAL(failure, true);
+    (void)DecodeBase64("invalid\0"s, &failure);
+    BOOST_CHECK(failure);
+    (void)DecodeBase64("nQB/pZw="s, &failure);
+    BOOST_CHECK(!failure);
+    (void)DecodeBase64("nQB/pZw=\0invalid"s, &failure);
+    BOOST_CHECK(failure);
+    (void)DecodeBase64("nQB/pZw=invalid\0"s, &failure);
+    BOOST_CHECK(failure);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -23,6 +23,8 @@
 #include <memory>
 #include <string>
 
+using namespace std::literals;
+
 class CAddrManSerializationMock : public CAddrMan
 {
 public:
@@ -104,8 +106,8 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     BOOST_CHECK(Lookup("250.7.1.1", addr1, 8333, false));
     BOOST_CHECK(Lookup("250.7.2.2", addr2, 9999, false));
     BOOST_CHECK(Lookup("250.7.3.3", addr3, 9999, false));
-    BOOST_CHECK(Lookup(std::string("250.7.3.3", 9), addr3, 9999, false));
-    BOOST_CHECK(!Lookup(std::string("250.7.3.3\0example.com", 21), addr3, 9999, false));
+    BOOST_CHECK(Lookup("250.7.3.3"s, addr3, 9999, false));
+    BOOST_CHECK(!Lookup("250.7.3.3\0example.com"s, addr3, 9999, false));
 
     // Add three addresses to new table.
     CService source;

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -12,6 +12,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using namespace std::literals;
+
 BOOST_FIXTURE_TEST_SUITE(netbase_tests, BasicTestingSetup)
 
 static CNetAddr ResolveIP(const std::string& ip)
@@ -427,20 +429,20 @@ BOOST_AUTO_TEST_CASE(netpermissions_test)
 BOOST_AUTO_TEST_CASE(netbase_dont_resolve_strings_with_embedded_nul_characters)
 {
     CNetAddr addr;
-    BOOST_CHECK(LookupHost(std::string("127.0.0.1", 9), addr, false));
-    BOOST_CHECK(!LookupHost(std::string("127.0.0.1\0", 10), addr, false));
-    BOOST_CHECK(!LookupHost(std::string("127.0.0.1\0example.com", 21), addr, false));
-    BOOST_CHECK(!LookupHost(std::string("127.0.0.1\0example.com\0", 22), addr, false));
+    BOOST_CHECK(LookupHost("127.0.0.1"s, addr, false));
+    BOOST_CHECK(!LookupHost("127.0.0.1\0"s, addr, false));
+    BOOST_CHECK(!LookupHost("127.0.0.1\0example.com"s, addr, false));
+    BOOST_CHECK(!LookupHost("127.0.0.1\0example.com\0"s, addr, false));
     CSubNet ret;
-    BOOST_CHECK(LookupSubNet(std::string("1.2.3.0/24", 10), ret));
-    BOOST_CHECK(!LookupSubNet(std::string("1.2.3.0/24\0", 11), ret));
-    BOOST_CHECK(!LookupSubNet(std::string("1.2.3.0/24\0example.com", 22), ret));
-    BOOST_CHECK(!LookupSubNet(std::string("1.2.3.0/24\0example.com\0", 23), ret));
+    BOOST_CHECK(LookupSubNet("1.2.3.0/24"s, ret));
+    BOOST_CHECK(!LookupSubNet("1.2.3.0/24\0"s, ret));
+    BOOST_CHECK(!LookupSubNet("1.2.3.0/24\0example.com"s, ret));
+    BOOST_CHECK(!LookupSubNet("1.2.3.0/24\0example.com\0"s, ret));
     // We only do subnetting for IPv4 and IPv6
-    BOOST_CHECK(!LookupSubNet(std::string("5wyqrzbvrdsumnok.onion", 22), ret));
-    BOOST_CHECK(!LookupSubNet(std::string("5wyqrzbvrdsumnok.onion\0", 23), ret));
-    BOOST_CHECK(!LookupSubNet(std::string("5wyqrzbvrdsumnok.onion\0example.com", 34), ret));
-    BOOST_CHECK(!LookupSubNet(std::string("5wyqrzbvrdsumnok.onion\0example.com\0", 35), ret));
+    BOOST_CHECK(!LookupSubNet("5wyqrzbvrdsumnok.onion"s, ret));
+    BOOST_CHECK(!LookupSubNet("5wyqrzbvrdsumnok.onion\0"s, ret));
+    BOOST_CHECK(!LookupSubNet("5wyqrzbvrdsumnok.onion\0example.com"s, ret));
+    BOOST_CHECK(!LookupSubNet("5wyqrzbvrdsumnok.onion\0example.com\0"s, ret));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -23,6 +23,7 @@
 
 #include <array>
 #include <stdint.h>
+#include <string.h>
 #include <thread>
 #include <univalue.h>
 #include <utility>
@@ -34,6 +35,8 @@
 #endif
 
 #include <boost/test/unit_test.hpp>
+
+using namespace std::literals;
 
 /* defined in logging.cpp */
 namespace BCLog {
@@ -1235,9 +1238,9 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney)
     BOOST_CHECK(!ParseMoney("-1", ret));
 
     // Parsing strings with embedded NUL characters should fail
-    BOOST_CHECK(!ParseMoney(std::string("\0-1", 3), ret));
-    BOOST_CHECK(!ParseMoney(std::string("\01", 2), ret));
-    BOOST_CHECK(!ParseMoney(std::string("1\0", 2), ret));
+    BOOST_CHECK(!ParseMoney("\0-1"s, ret));
+    BOOST_CHECK(!ParseMoney("\0" "1"s, ret));
+    BOOST_CHECK(!ParseMoney("1\0"s, ret));
 }
 
 BOOST_AUTO_TEST_CASE(util_IsHex)


### PR DESCRIPTION
A string literal `"abc"` contains a terminating `\0`, so that is 4
bytes. There is no need to write `"abc\0"` unless two terminating
`\0`s are necessary.

`std::string` objects do not internally contain a terminating `\0`, so
`std::string("abc")` creates a string with size 3 and is the same as
`std::string("abc", 3)`.

In `"\01"` the `01` part is interpreted as one number (1) and that is
the same as `"\1"` which is a string like `{1, 0}` whereas `"\0z"` is a
string like `{0, 'z', 0}`. To create a string like `{0, '1', 0}` one
must use `"\0" "1"`.

Adjust the tests accordingly.