### PR TITLE
netbase: remove unnecessary log message

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -624,7 +624,6 @@ std::unique_ptr<Sock> ConnectDirectly(const CService& dest, bool manual_connecti
     }
 
     if (!ConnectToSocket(*sock, (struct sockaddr*)&sockaddr, len, dest.ToStringAddrPort(), manual_connection)) {
-        LogPrintf("Cannot connect to socket for %s\n", dest.ToStringAddrPort());
         return {};
     }
 


### PR DESCRIPTION
This is a follow-up to `#27375` that removes a spammy non-debug-level log message we don't need. See `https://github.com/bitcoin/bitcoin/pull/27375#issuecomment-1994498888`